### PR TITLE
Sentry performance monitoring

### DIFF
--- a/integrations/sentry/lib/index.js
+++ b/integrations/sentry/lib/index.js
@@ -25,15 +25,16 @@ var Sentry = (module.exports = integration('Sentry')
   .option('maxMessageLength', null) // deprecated
   .option('logger', null)
   .option('customVersionProperty', null)
+  .option('tracesSampleRate', null)
   .option('debug', false)
   .tag(
     'sentry',
-    '<script src="https://browser.sentry-cdn.com/5.12.1/bundle.tracing.min.js" integrity="sha384-gDTsbUCgFQKbxNZj/RvveTOuAPZgNMjQzMdsD2TI/7YSPN+r49xERr43VxADcGVV" crossorigin="anonymous"></script>'
+    '<script src="https://browser.sentry-cdn.com/5.30.0/bundle.tracing.min.js" integrity="sha384-Wmp0Jx28tGfR086jrVwifMRcSWk8HQW4TWQ6XsNtI90pVj0dgkH9r2+pI3L2CLf6" crossorigin="anonymous"></script>'
   )
   // Sentry.Integrations.RewriteFrames plugin: https://docs.sentry.io/platforms/javascript/#rewriteframes
   .tag(
     'plugin',
-    '<script src="https://browser.sentry-cdn.com/5.12.1/rewriteframes.min.js" integrity="sha384-OGtEOqdWrmESHKrzGY/+Uf6hcr2FtZP4qdy2sCESccdGlCiqJVGxiNQadw8VFzBx" crossorigin="anonymous"></script>'
+    '<script src="https://browser.sentry-cdn.com/5.30.0/rewriteframes.min.js" integrity="sha384-22utNfjd1bJOgWt7yrPsUIWR7gluO23PO7d2m30lqrmnj5DH3OmVa8fwcwZhbfPp" crossorigin="anonymous"></script>'
   ));
 
 /**
@@ -59,6 +60,7 @@ Sentry.prototype.initialize = function() {
     // https://github.com/getsentry/sentry-javascript/blob/master/packages/core/src/integrations/inboundfilters.ts#L12
     ignoreErrors: this.options.ignoreErrors,
     integrations: [],
+    tracesSampleRate: this.options.tracesSampleRate,
     debug: this.options.debug
   };
 
@@ -100,6 +102,12 @@ Sentry.prototype.initialize = function() {
               return frame;
             }
           })
+        );
+      }
+
+      if (typeof config.tracesSampleRate === 'number') {
+        config.integrations.push(
+          new window.Sentry.Integrations.BrowserTracing()
         );
       }
 

--- a/integrations/sentry/lib/index.js
+++ b/integrations/sentry/lib/index.js
@@ -28,12 +28,12 @@ var Sentry = (module.exports = integration('Sentry')
   .option('debug', false)
   .tag(
     'sentry',
-    '<script src="https://browser.sentry-cdn.com/5.12.1/bundle.min.js" integrity="sha384-y+an4eARFKvjzOivf/Z7JtMJhaN6b+lLQ5oFbBbUwZNNVir39cYtkjW1r6Xjbxg3" crossorigin="anonymous"></script>'
+    '<script src="https://browser.sentry-cdn.com/5.12.1/bundle.tracing.min.js" integrity="sha384-gDTsbUCgFQKbxNZj/RvveTOuAPZgNMjQzMdsD2TI/7YSPN+r49xERr43VxADcGVV" crossorigin="anonymous"></script>'
   )
   // Sentry.Integrations.RewriteFrames plugin: https://docs.sentry.io/platforms/javascript/#rewriteframes
   .tag(
     'plugin',
-    '<script src="https://browser.sentry-cdn.com/5.12.1/rewriteframes.min.js" crossorigin="anonymous"></script>'
+    '<script src="https://browser.sentry-cdn.com/5.12.1/rewriteframes.min.js" integrity="sha384-OGtEOqdWrmESHKrzGY/+Uf6hcr2FtZP4qdy2sCESccdGlCiqJVGxiNQadw8VFzBx" crossorigin="anonymous"></script>'
   ));
 
 /**


### PR DESCRIPTION
**What does this PR do?**

It adds support for performance monitoring with the Sentry integration. The CDN link is updated to fetch a version of the bundle that includes the tracing code. An option is added to configure what percentage of sessions should be traced, and if that option is set then tracing is enabled. There's some relevant docs from Sentry [here](https://docs.sentry.io/platforms/javascript/#configure).

**Are there breaking changes in this PR?**

The version of Sentry that we were on did not provide performance tracking at all, so we had to update to a later Sentry version (as well as to the alternate bundle version that includes tracing). The latest version is v6.3.2, but I've just updated to v5.30.0. This is the latest release that keeps us on the same major version, and [NPM shows](https://www.npmjs.com/package/@sentry/tracing) it's the most-downloaded version per month at the moment. Seems a pretty safe bet, and I haven't seen any issues so far.